### PR TITLE
XCTest Link Errors and Unresolved struct access control issues 

### DIFF
--- a/Sources/MathParser/Evaluator.swift
+++ b/Sources/MathParser/Evaluator.swift
@@ -12,7 +12,7 @@ public struct Evaluator {
   @usableFromInline let usingImpliedMultiplication: Bool
 
   /// Obtain unresolved names of symbols for variables and functions
-  var unresolved: Unresolved { token.unresolved }
+  public var unresolved: Unresolved { token.unresolved }
   
   /**
    Construct new evaluator. This is constructed and returned by `MathParser.parse`.
@@ -101,14 +101,14 @@ struct EvalState {
   }
 }
 
-struct Unresolved {
-  let variables: Set<String>
-  let unaryFunctions: Set<String>
-  let binaryFunctions: Set<String>
+public struct Unresolved {
+  public let variables: Set<String>
+  public let unaryFunctions: Set<String>
+  public let binaryFunctions: Set<String>
 
-  var isEmpty: Bool { variables.isEmpty && unaryFunctions.isEmpty && binaryFunctions.isEmpty }
+  public var isEmpty: Bool { variables.isEmpty && unaryFunctions.isEmpty && binaryFunctions.isEmpty }
 
-  var count: Int { [variables, unaryFunctions, binaryFunctions]
+  public var count: Int { [variables, unaryFunctions, binaryFunctions]
     .map { $0.count }
     .sum()
   }

--- a/Sources/MathParser/MathParser.swift
+++ b/Sources/MathParser/MathParser.swift
@@ -2,7 +2,6 @@
 
 import Parsing
 import Foundation
-import XCTestDynamicOverlay
 
 /**
  General-purpose parser for simple math expressions made up of the common operations as well as single argument

--- a/Sources/MathParser/MathParser.swift
+++ b/Sources/MathParser/MathParser.swift
@@ -1,7 +1,8 @@
 // Copyright © 2021 Brad Howes. All rights reserved.
 
 import Parsing
-import XCTest
+import Foundation
+import XCTestDynamicOverlay
 
 /**
  General-purpose parser for simple math expressions made up of the common operations as well as single argument


### PR DESCRIPTION
I ran into problems linking a test app where XCTest was unresolved.  I also was not able to access the properties of the Unresolved struct as described in the README file.  Hopefully these changes are aligned with what you intended.